### PR TITLE
Make scheduler optional to avoid contention

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: redash
-version: 3.0.6
-appVersion: 10.0.0.b50363
+version: 3.0.7
+appVersion: 11.0.0-next
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:
   - redash

--- a/index.yaml
+++ b/index.yaml
@@ -29,6 +29,36 @@ entries:
     version: 8.10.14
   redash:
   - apiVersion: v1
+    appVersion: 11.0.0-next
+    created: "2024-12-11T19:11:11.302Z"
+    dependencies:
+    - condition: redis.enabled
+      name: redis
+      repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+      version: ^10.8.2
+    - condition: postgresql.enabled
+      name: postgresql
+      repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+      version: ^8.10.14
+    description: Redash is an open source tool built for teams to query, visualize
+      and collaborate.
+    digest: 7cf81a95bd067cc38d083a878ca3cd600fc7fe1751d8b53c4ec2dd0800938843
+    home: https://redash.io/
+    icon: https://redash.io/assets/images/elements/redash-logo.svg
+    keywords:
+    - redash
+    - analytics
+    - vizualisation
+    maintainers:
+    - email: jacob.brazeal@scale.com
+      name: Jacob Brazeal
+    name: redash
+    sources:
+    - https://github.com/getredash/redash
+    urls:
+    - release/redash-3.0.7.tgz
+    version: 3.0.7
+  - apiVersion: v1
     appVersion: 10.0.0.b50363
     created: "2024-02-08T17:08:35.988584-08:00"
     dependencies:

--- a/templates/scheduler-deployment.yaml
+++ b/templates/scheduler-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.skipSchedulerDeployment }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,3 +75,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}


### PR DESCRIPTION
Redash-dev and redash-next will disable the scheduler deployment because there can only be one. Pairs with this helmfile update: https://github.com/scaleapi/Terracode-Infra/pull/3858