### PR TITLE
feat; add secrets for approval

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -324,6 +324,23 @@ Shared environment block used across each component.
       name: {{ include "redash.secretName" . }}
       key: egpKBTables
 {{- end }}
+{{- if .Values.redash.existingSecret }}
+- name: REDASH_SNOWFLAKE_SERVICE_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redash.secretName" . }}
+      key: snowflakeServiceUser
+- name: REDASH_SNOWFLAKE_ACCOUNT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redash.secretName" . }}
+      key: snowflakeAccount
+- name: REDASH_SNOWFLAKE_WAREHOUSE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redash.secretName" . }}
+      key: snowflakeWarehouse
+{{- end }}
 {{- if .Values.redash.logLevel }}
 - name: REDASH_LOG_LEVEL
   value: {{ default  .Values.redash.logLevel | quote }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three Snowflake-related environment variables (`REDASH_SNOWFLAKE_SERVICE_USER`, `REDASH_SNOWFLAKE_ACCOUNT`, `REDASH_SNOWFLAKE_WAREHOUSE`) to the shared environment block in `_helpers.tpl`, sourced from Kubernetes secrets.

- The new variables are guarded solely by `{{- if .Values.redash.existingSecret }}`, which differs from the `if or` pattern used by other secret-backed env vars in this file. This means **any deployment using `existingSecret` will now require these three keys to be present** in the external secret, even if Snowflake is not in use — potentially breaking existing deployments.
- No corresponding entries were added to `values.yaml` or `secrets.yaml`, so these secrets are only available via the external secret path.
- Consider using the established `if or` guard pattern or a separate feature flag to make Snowflake opt-in rather than mandatory for all `existingSecret` users.

<details><summary><h3>Confidence Score: 2/5</h3></summary>

- This PR may break existing deployments that use `existingSecret` without Snowflake keys in the secret.
- The unconditional injection of Snowflake secret refs when `existingSecret` is set will cause pod startup failures for any deployment that uses an external secret but doesn't include the three new Snowflake keys. This is a backwards-compatibility concern that could affect production deployments.
- `templates/_helpers.tpl` — the new Snowflake secret block (lines 327-343) needs a more targeted guard condition.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| templates/_helpers.tpl | Adds three Snowflake-related secret env vars (service user, account, warehouse) guarded only by `existingSecret`, which will break existing deployments that use `existingSecret` without Snowflake keys present. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Helm Deploy"] --> B{"redash.existingSecret set?"}
    B -- No --> C["Skip Snowflake env vars"]
    B -- Yes --> D["Inject REDASH_SNOWFLAKE_SERVICE_USER\nREDASH_SNOWFLAKE_ACCOUNT\nREDASH_SNOWFLAKE_WAREHOUSE\nfrom secret"]
    D --> E{"Keys exist in secret?"}
    E -- Yes --> F["Pod starts successfully"]
    E -- No --> G["CreateContainerConfigError\n(Pod fails to start)"]
    style G fill:#f96,stroke:#c00
```
</details>


<sub>Last reviewed commit: 863d028</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->