### PR TITLE
feat: expose DUA Agentex credentials to Redash

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 3.0.12
+version: 3.0.13
 appVersion: 11.0.0-next
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -324,6 +324,20 @@ Shared environment block used across each component.
       name: {{ include "redash.secretName" . }}
       key: egpKBTables
 {{- end }}
+{{- if or .Values.redash.duaAgentexAPIKey .Values.redash.existingSecret }}
+- name: DUA_AGENTEX_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redash.secretName" . }}
+      key: duaAgentexAPIKey
+{{- end }}
+{{- if or .Values.redash.duaAgentexAccountId .Values.redash.existingSecret }}
+- name: DUA_AGENTEX_ACCOUNT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "redash.secretName" . }}
+      key: duaAgentexAccountId
+{{- end }}
 {{- if .Values.redash.existingSecret }}
 - name: REDASH_SNOWFLAKE_SERVICE_USER
   valueFrom:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -20,6 +20,8 @@ data:
   egpAccountId: {{ default "" .Values.redash.egpAccountId | b64enc | quote }}
   egpKBQueries: {{ default "" .Values.redash.egpKBQueries | b64enc | quote }}
   egpKBTables: {{ default "" .Values.redash.egpKBTables | b64enc | quote }}
+  duaAgentexAPIKey: {{ default "" .Values.redash.duaAgentexAPIKey | b64enc | quote }}
+  duaAgentexAccountId: {{ default "" .Values.redash.duaAgentexAccountId | b64enc | quote }}
   mailPassword: {{ default "" .Values.redash.mailPassword | b64enc | quote }}
   ## End primary Redash configuration
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,10 @@ redash:
   egpKBQueries: ""
   # -- REQUIRED `REDASH_EGP_KB_TABLES` value. Vector search tables.
   egpKBTables: ""
+  # -- `DUA_AGENTEX_API_KEY` value. DUA agentex API key. Stored as a Secret value.
+  duaAgentexAPIKey: ""
+  # -- `DUA_AGENTEX_ACCOUNT_ID` value. DUA agentex account id. Stored as a Secret value.
+  duaAgentexAccountId: ""
   # -- `REDASH_SAML_SCHEME_OVERRIDE` value. This setting will allow you to override the saml auth url scheme that gets constructed by flask. this is a useful feature if, for example, you're behind a proxy protocol enabled tcp load balancer (aws elb that terminates ssl) and your nginx proxy or similar adds a x-forwarded-proto of http even though your redash url for saml auth is https..
   samlSchemeOverride: ""
   # -- `REDASH_PROXIES_COUNT` value.


### PR DESCRIPTION
## Summary

Exposes the two Agentex credentials required by DUA and bumps the chart from `3.0.12` to `3.0.13`.

## Changes

- Maps `duaAgentexAPIKey` to `DUA_AGENTEX_API_KEY`.
- Maps `duaAgentexAccountId` to `DUA_AGENTEX_ACCOUNT_ID`.
- Supports both chart-managed and existing Redash secrets.

This is additive, but releases using an existing secret must add both keys before upgrading to `3.0.13`.

## Related

- Application: [scaleapi/redash#128](https://github.com/scaleapi/redash/pull/128)
- Deployment: [scaleapi/Terracode-Infra#8398](https://github.com/scaleapi/Terracode-Infra/pull/8398)
- Tracking: [PLA4-40261](https://linear.app/scale-epd/issue/PLA4-40261/integrate-dua-to-redash)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new Agentex credentials (`DUA_AGENTEX_API_KEY`, `DUA_AGENTEX_ACCOUNT_ID`) to the Redash Helm chart and bumps the version to `3.0.13`. The implementation follows the exact same pattern as the existing EGP credentials — values stored in the chart-managed Secret when no `existingSecret` is configured, and env vars injected conditionally using the `or <value> .Values.redash.existingSecret` guard.

- New `duaAgentexAPIKey` and `duaAgentexAccountId` fields added to `values.yaml` with empty defaults; corresponding keys written to `templates/secrets.yaml` when the chart manages the Secret.
- Two new env-var blocks in `templates/_helpers.tpl` expose the credentials to the Redash container, consistent with the existing EGP credential pattern.
- As documented in the PR description, deployments using an `existingSecret` must add both new keys to that secret before upgrading to `3.0.13`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Additive chart change that mirrors an already-proven credential pattern; no existing behavior is altered.

All four files are updated consistently. The new keys follow the identical guard pattern used for the EGP credentials, the chart-managed Secret template correctly includes the new keys, and the env-var blocks in _helpers.tpl are properly conditioned. No logic is changed for existing deployments that don't set the new values.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Chart.yaml | Chart version bumped from 3.0.12 to 3.0.13 to reflect the new credentials addition. |
| values.yaml | Two new optional values added (`duaAgentexAPIKey`, `duaAgentexAccountId`) with empty-string defaults; follows existing EGP key conventions. |
| templates/secrets.yaml | New keys added to chart-managed Secret; correctly guarded by `not .Values.redash.existingSecret` via the template's outer conditional. |
| templates/_helpers.tpl | Two new env-var blocks injected following the identical `or .Values.redash.duaAgentex* .Values.redash.existingSecret` guard pattern used by existing EGP keys. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Helm Install / Upgrade] --> B{existingSecret set?}
    B -- No --> C[secrets.yaml creates\nmanaged Secret\nwith duaAgentexAPIKey\n& duaAgentexAccountId]
    B -- Yes --> D[Operator-managed\nexternal Secret\nmust already contain\nboth keys]
    C --> E[_helpers.tpl injects\nDUA_AGENTEX_API_KEY\nif value OR existingSecret]
    D --> E
    E --> F[_helpers.tpl injects\nDUA_AGENTEX_ACCOUNT_ID\nif value OR existingSecret]
    F --> G[Redash Pod\nreads env vars\nDUA_AGENTEX_API_KEY\nDUA_AGENTEX_ACCOUNT_ID]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Helm Install / Upgrade] --> B{existingSecret set?}
    B -- No --> C[secrets.yaml creates\nmanaged Secret\nwith duaAgentexAPIKey\n& duaAgentexAccountId]
    B -- Yes --> D[Operator-managed\nexternal Secret\nmust already contain\nboth keys]
    C --> E[_helpers.tpl injects\nDUA_AGENTEX_API_KEY\nif value OR existingSecret]
    D --> E
    E --> F[_helpers.tpl injects\nDUA_AGENTEX_ACCOUNT_ID\nif value OR existingSecret]
    F --> G[Redash Pod\nreads env vars\nDUA_AGENTEX_API_KEY\nDUA_AGENTEX_ACCOUNT_ID]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: DUA agentex secret env mappings (D..."](https://github.com/scaleapi/redash-helm-chart/commit/4fd762852e57009da60734543236c94091191e0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44603770)</sub>

<!-- /greptile_comment -->