### PR TITLE
feat(dua): add optional dedicated server pool

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 3.0.13
+version: 3.0.14
 appVersion: 11.0.0-next
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -43,11 +43,11 @@ spec:
       # being SIGKILLed at the default 30s (turns aren't resumable — agentex has no replay).
       terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds | default 90 }}
       securityContext:
-        {{- toYaml .Values.duaServer.podSecurityContext | nindent 8 }}
+        {{- toYaml (.Values.duaServer.podSecurityContext | default .Values.server.podSecurityContext) | nindent 8 }}
       containers:
         - name: {{ include "redash.name" . }}-dua-server
           securityContext:
-            {{- toYaml .Values.duaServer.securityContext | nindent 12 }}
+            {{- toYaml (.Values.duaServer.securityContext | default .Values.server.securityContext) | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh"]
@@ -55,6 +55,10 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+            # Inherit the main server's mounts (e.g. the Snowflake key) + any dua-specific extras.
+            {{- with .Values.server.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.duaServer.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -108,18 +112,21 @@ spec:
         - name: config
           configMap:
             name: {{ include "redash.fullname" . }}
+        {{- with .Values.server.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.duaServer.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    {{- with .Values.duaServer.nodeSelector }}
+    {{- with (.Values.duaServer.nodeSelector | default .Values.server.nodeSelector) }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.duaServer.affinity }}
+    {{- with (.Values.duaServer.affinity | default .Values.server.affinity) }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.duaServer.tolerations }}
+    {{- with (.Values.duaServer.tolerations | default .Values.server.tolerations) }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.duaServer.enabled }}
-# Isolated DUA server: serves /api/dua/* on a dedicated gthread pool so long SSE turns never occupy
-# the main web pool. Near-clone of server-deployment.yaml — KEEP THE POD SPEC IN SYNC with it; the
-# only intended differences are the gunicorn worker vars + grace period.
+# Dedicated DUA server for long-lived /api/dua/* requests.
+# Keep shared application settings aligned with server-deployment.yaml.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,8 +37,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
-      # Grace for in-flight SSE turns to drain on shutdown. Owned by values.yaml (must cover
-      # preStopDrainSeconds + gunicorn --graceful-timeout).
+      # Must cover preStopDrainSeconds plus Gunicorn's graceful timeout.
       terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml (.Values.duaServer.podSecurityContext | default .Values.server.podSecurityContext) | nindent 8 }}
@@ -54,16 +52,13 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-            # Inherit the main server's mounts + any dua-specific extras.
-            {{- with .Values.server.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            # Do not inherit server mounts; DUA does not need the Snowflake key.
             {{- with .Values.duaServer.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
           {{- include "redash.env" . | nindent 12 }}
-          # Inherit the main server's app config (server.env); dua-specific worker vars follow.
+          # Reuse server app configuration; DUA worker settings follow.
           {{- range $key, $value := .Values.server.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -74,7 +69,7 @@ spec:
               value: "{{ .Values.duaServer.workerClass }}"
             - name: GUNICORN_THREADS
               value: "{{ .Values.duaServer.threads }}"
-          # duaServer.env last: on a key collision it intentionally overrides server.env (k8s last-wins).
+          # DUA-specific values intentionally override server.env.
           {{- range $key, $value := .Values.duaServer.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -87,9 +82,9 @@ spec:
           {{- include "redash.envFrom" . | nindent 12 }}
           ports:
             - containerPort: {{ .Values.server.httpPort }}
+          # TCP liveness avoids false restarts when gthread workers are saturated.
           livenessProbe:
-            httpGet:
-              path: /ping
+            tcpSocket:
               port: {{ .Values.server.httpPort }}
             initialDelaySeconds: 90
             timeoutSeconds: 1
@@ -105,10 +100,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
-          # preStop drain: sleep so Istio removes this pod from the EndpointSlice before gunicorn
-          # stops accepting, so NEW /api/dua turns don't land on a terminating pod (retries are
-          # disabled for /api/dua/*, so a refused new turn fails outright). NOTE: this holds the app
-          # open, not the istio sidecar — pair with the mesh-side drain (deploy repo) to fully close it.
+          # Allow endpoint removal to propagate before Gunicorn shuts down.
           lifecycle:
             preStop:
               exec:
@@ -119,9 +111,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "redash.fullname" . }}
-        {{- with .Values.server.volumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- with .Values.duaServer.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -138,7 +127,6 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- if .Values.duaServer.topologySpread.enabled }}
-      # Spread pods across nodes so a single node loss can't take out the whole isolated pool.
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -47,8 +47,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
-      # Streaming service: allow in-flight SSE turns to drain on rollout / node drain instead of
-      # being SIGKILLed at the default 30s (turns aren't resumable — agentex has no replay).
+      # Pod shutdown grace (turns aren't resumable — agentex has no replay). NOTE: on a ROLLOUT the
+      # istio sidecar drains (~5s, not configured to hold) and cuts an in-flight SSE turn regardless
+      # of this value — see slice1 doc finding A. The frequent worker-recycle path is covered by
+      # gunicorn --graceful-timeout (set via GUNICORN_CMD_ARGS in duaServer.env).
       terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds | default 90 }}
       securityContext:
         {{- toYaml (.Values.duaServer.podSecurityContext | default .Values.server.podSecurityContext) | nindent 8 }}

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.duaServer.enabled }}
+# ============================================================================================
+# KEEP THE POD SPEC IN SYNC WITH server-deployment.yaml.
+# This is a deliberate near-clone of the main server (see dua_scaling_slice1.md "Code-review
+# findings #3" for why we keep two explicit files rather than a shared template). Any change to
+# the server pod spec — env, volumes/volumeMounts, probes, ports, resources, securityContext,
+# command — must be mirrored here, or inherited from .Values.server.* (as env/volumes/security
+# already are). The only intended differences are the gunicorn worker vars + grace period.
+# ============================================================================================
 # Isolated DUA server: serves /api/dua/* on its own pool so long streaming turns never occupy the
 # main web pool. Same image + entrypoint as the main server; the only difference is the gunicorn
 # worker class/threads (gthread) so a blocked SSE stream occupies a thread, not the whole process.

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.duaServer.enabled }}
+# Isolated DUA server: serves /api/dua/* on its own pool so long streaming turns never occupy the
+# main web pool. Same image + entrypoint as the main server; the only difference is the gunicorn
+# worker class/threads (gthread) so a blocked SSE stream occupies a thread, not the whole process.
+# Routing of /api/dua/* to this deployment's Service is done in the istio VirtualService (deploy repo).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redash.fullname" . }}-dua-server
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dua-server
+spec:
+  replicas: {{ .Values.duaServer.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "redash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dua-server
+  template:
+    metadata:
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: dua-server
+        {{- if .Values.duaServer.podLabels }}
+        {{- tpl (toYaml .Values.duaServer.podLabels) $ | nindent 8 }}
+        {{- end }}
+      {{- if .Values.duaServer.podAnnotations }}
+      annotations:
+      {{ toYaml .Values.duaServer.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "redash.serviceAccountName" . }}
+      # Streaming service: allow in-flight SSE turns to drain on rollout / node drain instead of
+      # being SIGKILLed at the default 30s (turns aren't resumable — agentex has no replay).
+      terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds | default 90 }}
+      securityContext:
+        {{- toYaml .Values.duaServer.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "redash.name" . }}-dua-server
+          securityContext:
+            {{- toYaml .Values.duaServer.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint server"]
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            {{- with .Values.duaServer.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+          {{- include "redash.env" . | nindent 12 }}
+          # Inherit the main server's app config (agentex URL/model/KB, Unleash URL, CSP, ...) so the
+          # DUA pool is the same app as the main server — differing ONLY in the gunicorn worker vars below.
+          {{- range $key, $value := .Values.server.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+            - name: REDASH_WEB_WORKERS
+              value: "{{ .Values.duaServer.webWorkers }}"
+            - name: GUNICORN_WORKER_CLASS
+              value: "{{ .Values.duaServer.workerClass }}"
+            - name: GUNICORN_THREADS
+              value: "{{ .Values.duaServer.threads }}"
+          {{- range $key, $value := .Values.duaServer.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          envFrom:
+          {{- include "redash.envFrom" . | nindent 12 }}
+          ports:
+            - containerPort: {{ .Values.server.httpPort }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.server.httpPort }}
+            initialDelaySeconds: 90
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.server.httpPort }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+{{ toYaml .Values.duaServer.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "redash.fullname" . }}
+        {{- with .Values.duaServer.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    {{- with .Values.duaServer.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.duaServer.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.duaServer.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -38,8 +38,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
-      # Grace for in-flight SSE turns to drain on shutdown.
-      terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds | default 90 }}
+      # Grace for in-flight SSE turns to drain on shutdown. Owned by values.yaml (must cover
+      # preStopDrainSeconds + gunicorn --graceful-timeout).
+      terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml (.Values.duaServer.podSecurityContext | default .Values.server.podSecurityContext) | nindent 8 }}
       containers:
@@ -73,6 +74,7 @@ spec:
               value: "{{ .Values.duaServer.workerClass }}"
             - name: GUNICORN_THREADS
               value: "{{ .Values.duaServer.threads }}"
+          # duaServer.env last: on a key collision it intentionally overrides server.env (k8s last-wins).
           {{- range $key, $value := .Values.duaServer.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -103,6 +105,14 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          # preStop drain: sleep so Istio removes this pod from the EndpointSlice before gunicorn
+          # stops accepting, so NEW /api/dua turns don't land on a terminating pod (retries are
+          # disabled for /api/dua/*, so a refused new turn fails outright). NOTE: this holds the app
+          # open, not the istio sidecar — pair with the mesh-side drain (deploy repo) to fully close it.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep {{ .Values.duaServer.preStopDrainSeconds }}"]
           resources:
 {{ toYaml .Values.duaServer.resources | indent 12 }}
       volumes:
@@ -126,5 +136,16 @@ spec:
     {{- with (.Values.duaServer.tolerations | default .Values.server.tolerations) }}
       tolerations:
 {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if .Values.duaServer.topologySpread.enabled }}
+      # Spread pods across nodes so a single node loss can't take out the whole isolated pool.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.duaServer.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "redash.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: dua-server
     {{- end }}
 {{- end }}

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -1,16 +1,7 @@
 {{- if .Values.duaServer.enabled }}
-# ============================================================================================
-# KEEP THE POD SPEC IN SYNC WITH server-deployment.yaml.
-# This is a deliberate near-clone of the main server (see dua_scaling_slice1.md "Code-review
-# findings #3" for why we keep two explicit files rather than a shared template). Any change to
-# the server pod spec — env, volumes/volumeMounts, probes, ports, resources, securityContext,
-# command — must be mirrored here, or inherited from .Values.server.* (as env/volumes/security
-# already are). The only intended differences are the gunicorn worker vars + grace period.
-# ============================================================================================
-# Isolated DUA server: serves /api/dua/* on its own pool so long streaming turns never occupy the
-# main web pool. Same image + entrypoint as the main server; the only difference is the gunicorn
-# worker class/threads (gthread) so a blocked SSE stream occupies a thread, not the whole process.
-# Routing of /api/dua/* to this deployment's Service is done in the istio VirtualService (deploy repo).
+# Isolated DUA server: serves /api/dua/* on a dedicated gthread pool so long SSE turns never occupy
+# the main web pool. Near-clone of server-deployment.yaml — KEEP THE POD SPEC IN SYNC with it; the
+# only intended differences are the gunicorn worker vars + grace period.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,10 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
-      # Pod shutdown grace (turns aren't resumable — agentex has no replay). NOTE: on a ROLLOUT the
-      # istio sidecar drains (~5s, not configured to hold) and cuts an in-flight SSE turn regardless
-      # of this value — see slice1 doc finding A. The frequent worker-recycle path is covered by
-      # gunicorn --graceful-timeout (set via GUNICORN_CMD_ARGS in duaServer.env).
+      # Grace for in-flight SSE turns to drain on shutdown.
       terminationGracePeriodSeconds: {{ .Values.duaServer.terminationGracePeriodSeconds | default 90 }}
       securityContext:
         {{- toYaml (.Values.duaServer.podSecurityContext | default .Values.server.podSecurityContext) | nindent 8 }}
@@ -65,7 +53,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-            # Inherit the main server's mounts (e.g. the Snowflake key) + any dua-specific extras.
+            # Inherit the main server's mounts + any dua-specific extras.
             {{- with .Values.server.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -74,8 +62,7 @@ spec:
             {{- end }}
           env:
           {{- include "redash.env" . | nindent 12 }}
-          # Inherit the main server's app config (agentex URL/model/KB, Unleash URL, CSP, ...) so the
-          # DUA pool is the same app as the main server — differing ONLY in the gunicorn worker vars below.
+          # Inherit the main server's app config (server.env); dua-specific worker vars follow.
           {{- range $key, $value := .Values.server.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/templates/dua-server-deployment.yaml
+++ b/templates/dua-server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 10
+          # HTTP readiness intentionally sheds new traffic when all gthread slots are occupied;
+          # TCP liveness above keeps a healthy saturated pod from being restarted.
           readinessProbe:
             httpGet:
               path: /ping

--- a/templates/dua-server-pdb.yaml
+++ b/templates/dua-server-pdb.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.duaServer.enabled .Values.duaServer.pdb.enabled }}
-# Keeps at least minAvailable DUA server pods during voluntary disruptions (node drains, upgrades),
-# matching the existing redash-server PDB pattern.
+# Limits voluntary disruption (node drains, upgrades) of the DUA pool. This is the only
+# chart-managed PDB; the main redash-server's PDB (if any) is defined in the deploy repo, not here.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ metadata:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: dua-server
 spec:
-  minAvailable: {{ .Values.duaServer.pdb.minAvailable }}
+  maxUnavailable: {{ .Values.duaServer.pdb.maxUnavailable }}
   selector:
     matchLabels:
       {{- include "redash.selectorLabels" . | nindent 6 }}

--- a/templates/dua-server-pdb.yaml
+++ b/templates/dua-server-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.duaServer.enabled .Values.duaServer.pdb.enabled }}
+# Keeps at least minAvailable DUA server pods during voluntary disruptions (node drains, upgrades),
+# matching the existing redash-server PDB pattern.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "redash.fullname" . }}-dua-server
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dua-server
+spec:
+  minAvailable: {{ .Values.duaServer.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "redash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dua-server
+{{- end }}

--- a/templates/dua-server-pdb.yaml
+++ b/templates/dua-server-pdb.yaml
@@ -1,7 +1,10 @@
 {{- if and .Values.duaServer.enabled .Values.duaServer.pdb.enabled }}
-# Limits voluntary disruption (node drains, upgrades) of the DUA pool. This is the only
-# chart-managed PDB; the main redash-server's PDB (if any) is defined in the deploy repo, not here.
+# Protect DUA capacity during voluntary disruptions.
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "redash.fullname" . }}-dua-server

--- a/templates/dua-server-service.yaml
+++ b/templates/dua-server-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.duaServer.enabled }}
+# Service for the isolated DUA server. The istio VirtualService routes uri prefix /api/dua/ to this
+# Service (host: {{ include "redash.fullname" . }}-dua-server), keeping the default route to the main server.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redash.fullname" . }}-dua-server
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dua-server
+  annotations:
+  {{- with .Values.service.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.server.httpPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "redash.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dua-server
+{{- end }}

--- a/templates/dua-server-service.yaml
+++ b/templates/dua-server-service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.duaServer.enabled }}
-# Service for the isolated DUA server; the istio VirtualService routes /api/dua/ here.
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,13 +6,12 @@ metadata:
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: dua-server
-  # Own annotations (not the main service's): this is an internal ClusterIP reached only via istio.
   annotations:
   {{- with .Values.duaServer.service.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # ClusterIP (not .Values.service.type): only reached via the istio gateway, never externally.
+  # Internal ClusterIP; ingress is provided by the Istio VirtualService.
   type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}

--- a/templates/dua-server-service.yaml
+++ b/templates/dua-server-service.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.duaServer.enabled }}
-# Service for the isolated DUA server. The istio VirtualService routes uri prefix /api/dua/ to this
-# Service (host: {{ include "redash.fullname" . }}-dua-server), keeping the default route to the main server.
+# Service for the isolated DUA server; the istio VirtualService routes /api/dua/ here.
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,8 +12,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Pinned to ClusterIP (not .Values.service.type): this Service is only ever reached via the istio
-  # gateway/VirtualService, so it must never inherit an external LoadBalancer/NodePort type.
+  # ClusterIP (not .Values.service.type): only reached via the istio gateway, never externally.
   type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}

--- a/templates/dua-server-service.yaml
+++ b/templates/dua-server-service.yaml
@@ -7,8 +7,9 @@ metadata:
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: dua-server
+  # Own annotations (not the main service's): this is an internal ClusterIP reached only via istio.
   annotations:
-  {{- with .Values.service.annotations }}
+  {{- with .Values.duaServer.service.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/templates/dua-server-service.yaml
+++ b/templates/dua-server-service.yaml
@@ -13,7 +13,9 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  # Pinned to ClusterIP (not .Values.service.type): this Service is only ever reached via the istio
+  # gateway/VirtualService, so it must never inherit an external LoadBalancer/NodePort type.
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.server.httpPort }}

--- a/values.yaml
+++ b/values.yaml
@@ -383,43 +383,37 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-## Configuration for the isolated DUA (Data Understanding Agent) server.
-## Serves /api/dua/* on its own pool (routed via the istio VirtualService) so long streaming turns
-## never occupy the main web pool. Disabled by default; enabling it is additive and reversible.
+## Dedicated server pool for long-lived /api/dua/* requests.
 duaServer:
   # duaServer.enabled -- create the dedicated DUA server Deployment + Service
   enabled: false
   # duaServer.replicaCount -- number of DUA server pods
   replicaCount: 2
-  # duaServer.workerClass -- gunicorn worker class; gthread lets a blocked SSE stream occupy a
-  # thread (not the whole process) with no gevent monkeypatch / psycopg2 risk
+  # duaServer.workerClass -- Gunicorn worker class for concurrent streams.
   workerClass: gthread
   # duaServer.threads -- threads per worker (≈ concurrent streams per worker)
   threads: 16
   # duaServer.webWorkers -- gunicorn worker processes per pod
   webWorkers: 2
-  # duaServer.resources -- requests/limits (set explicitly: DUA is I/O-bound / low-CPU; don't run unbounded)
+  # duaServer.resources -- Resource requests and limits for DUA server pods.
   resources:
     requests: { cpu: 250m, memory: 1Gi }
     limits:   { cpu: "1",  memory: 3Gi }
-  # duaServer.terminationGracePeriodSeconds -- total pod-shutdown budget. Must cover
-  # preStopDrainSeconds + gunicorn --graceful-timeout (15 + 300 = 315), else k8s SIGKILLs mid-drain.
+  # duaServer.terminationGracePeriodSeconds -- Pod shutdown budget; must exceed preStop plus Gunicorn drain.
   terminationGracePeriodSeconds: 320
-  # duaServer.preStopDrainSeconds -- sleep before SIGTERM so Istio de-registers the pod from the
-  # EndpointSlice before gunicorn stops accepting (keeps new turns off a terminating pod).
+  # duaServer.preStopDrainSeconds -- Delay before SIGTERM while endpoint removal propagates.
   preStopDrainSeconds: 15
-  # duaServer.pdb -- PodDisruptionBudget for the DUA pool (the only PDB in this chart).
-  # maxUnavailable (not minAvailable): drain-safe at any replicaCount -- minAvailable:1 would
-  # deadlock node drains when replicaCount is 1 (disruptionsAllowed = healthy - minAvailable = 0).
+  # duaServer.pdb -- Disruption budget for the DUA pool.
+  # maxUnavailable avoids blocking drains when replicaCount is 1.
   pdb:
     enabled: true
     maxUnavailable: 1
-  # duaServer.env -- extra env. GUNICORN_CMD_ARGS raises gunicorn's graceful-timeout so a recycling
-  # worker drains its in-flight SSE turn instead of cutting it at the 30s default.
+  # duaServer.env -- Additional environment variables.
+  # Allow 300s graceful drain and disable recycling to preserve pool capacity.
   env:
     GUNICORN_CMD_ARGS: "--graceful-timeout 300"
-  # duaServer.service.annotations -- annotations for the DUA Service, independent of service.annotations
-  # (the main external service): this is an internal ClusterIP reached only via the istio VirtualService.
+    MAX_REQUESTS: "0"
+  # duaServer.service.annotations -- Annotations for the internal DUA Service.
   service:
     annotations: {}
   podSecurityContext: {}
@@ -427,8 +421,7 @@ duaServer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # duaServer.topologySpread -- spread pods across nodes (soft) so one node loss can't take out the
-  # whole isolated pool. ScheduleAnyway keeps it non-blocking; selects only dua-server pods.
+  # duaServer.topologySpread -- Spread replicas across nodes when possible.
   topologySpread:
     enabled: true
     whenUnsatisfiable: ScheduleAnyway

--- a/values.yaml
+++ b/values.yaml
@@ -383,6 +383,43 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+## Configuration for the isolated DUA (Data Understanding Agent) server.
+## Serves /api/dua/* on its own pool (routed via the istio VirtualService) so long streaming turns
+## never occupy the main web pool. Disabled by default; enabling it is additive and reversible.
+duaServer:
+  # duaServer.enabled -- create the dedicated DUA server Deployment + Service
+  enabled: false
+  # duaServer.replicaCount -- number of DUA server pods
+  replicaCount: 2
+  # duaServer.workerClass -- gunicorn worker class; gthread lets a blocked SSE stream occupy a
+  # thread (not the whole process) with no gevent monkeypatch / psycopg2 risk
+  workerClass: gthread
+  # duaServer.threads -- threads per worker (≈ concurrent streams per worker)
+  threads: 16
+  # duaServer.webWorkers -- gunicorn worker processes per pod
+  webWorkers: 2
+  # duaServer.resources -- requests/limits (set explicitly: DUA is I/O-bound / low-CPU; don't run unbounded)
+  resources:
+    requests: { cpu: 250m, memory: 1Gi }
+    limits:   { cpu: "1",  memory: 3Gi }
+  # duaServer.terminationGracePeriodSeconds -- let in-flight SSE turns drain on rollout/drain
+  terminationGracePeriodSeconds: 90
+  # duaServer.pdb -- PodDisruptionBudget (matches the redash-server PDB; keeps >=1 pod during drains)
+  pdb:
+    enabled: true
+    minAvailable: 1
+  # duaServer.env -- extra env vars merged with the shared env
+  env: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+  podLabels: {}
+  volumes: []
+  volumeMounts: []
+
 ## Configuration for Redash ad-hoc workers
 workers:
   # Can have multiple of these

--- a/values.yaml
+++ b/values.yaml
@@ -402,21 +402,36 @@ duaServer:
   resources:
     requests: { cpu: 250m, memory: 1Gi }
     limits:   { cpu: "1",  memory: 3Gi }
-  # duaServer.terminationGracePeriodSeconds -- grace for in-flight SSE turns to drain on shutdown
-  terminationGracePeriodSeconds: 90
-  # duaServer.pdb -- PodDisruptionBudget (matches the redash-server PDB; keeps >=1 pod during drains)
+  # duaServer.terminationGracePeriodSeconds -- total pod-shutdown budget. Must cover
+  # preStopDrainSeconds + gunicorn --graceful-timeout (15 + 300 = 315), else k8s SIGKILLs mid-drain.
+  terminationGracePeriodSeconds: 320
+  # duaServer.preStopDrainSeconds -- sleep before SIGTERM so Istio de-registers the pod from the
+  # EndpointSlice before gunicorn stops accepting (keeps new turns off a terminating pod).
+  preStopDrainSeconds: 15
+  # duaServer.pdb -- PodDisruptionBudget for the DUA pool (the only PDB in this chart).
+  # maxUnavailable (not minAvailable): drain-safe at any replicaCount -- minAvailable:1 would
+  # deadlock node drains when replicaCount is 1 (disruptionsAllowed = healthy - minAvailable = 0).
   pdb:
     enabled: true
-    minAvailable: 1
+    maxUnavailable: 1
   # duaServer.env -- extra env. GUNICORN_CMD_ARGS raises gunicorn's graceful-timeout so a recycling
   # worker drains its in-flight SSE turn instead of cutting it at the 30s default.
   env:
     GUNICORN_CMD_ARGS: "--graceful-timeout 300"
+  # duaServer.service.annotations -- annotations for the DUA Service, independent of service.annotations
+  # (the main external service): this is an internal ClusterIP reached only via the istio VirtualService.
+  service:
+    annotations: {}
   podSecurityContext: {}
   securityContext: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # duaServer.topologySpread -- spread pods across nodes (soft) so one node loss can't take out the
+  # whole isolated pool. ScheduleAnyway keeps it non-blocking; selects only dua-server pods.
+  topologySpread:
+    enabled: true
+    whenUnsatisfiable: ScheduleAnyway
   podAnnotations: {}
   podLabels: {}
   volumes: []

--- a/values.yaml
+++ b/values.yaml
@@ -402,14 +402,20 @@ duaServer:
   resources:
     requests: { cpu: 250m, memory: 1Gi }
     limits:   { cpu: "1",  memory: 3Gi }
-  # duaServer.terminationGracePeriodSeconds -- let in-flight SSE turns drain on rollout/drain
+  # duaServer.terminationGracePeriodSeconds -- pod shutdown grace. NOTE: on a ROLLOUT an in-flight SSE
+  # turn is still cut at the istio sidecar drain (~5s, not configured to hold) regardless of this value
+  # -- see dua_scaling_slice1.md finding A. The frequent worker-recycle path is covered by env.GUNICORN_CMD_ARGS.
   terminationGracePeriodSeconds: 90
   # duaServer.pdb -- PodDisruptionBudget (matches the redash-server PDB; keeps >=1 pod during drains)
   pdb:
     enabled: true
     minAvailable: 1
-  # duaServer.env -- extra env vars merged with the shared env
-  env: {}
+  # duaServer.env -- extra env vars merged with the shared env.
+  # GUNICORN_CMD_ARGS raises gunicorn's graceful-timeout (default 30s) so a worker recycling on
+  # --max-requests drains an in-flight SSE turn (bounded by the ~270s app abort) instead of cutting
+  # it at 30s. Covers the frequent worker-recycle path; the rollout path also needs istio (finding A).
+  env:
+    GUNICORN_CMD_ARGS: "--graceful-timeout 300"
   podSecurityContext: {}
   securityContext: {}
   nodeSelector: {}

--- a/values.yaml
+++ b/values.yaml
@@ -402,18 +402,14 @@ duaServer:
   resources:
     requests: { cpu: 250m, memory: 1Gi }
     limits:   { cpu: "1",  memory: 3Gi }
-  # duaServer.terminationGracePeriodSeconds -- pod shutdown grace. NOTE: on a ROLLOUT an in-flight SSE
-  # turn is still cut at the istio sidecar drain (~5s, not configured to hold) regardless of this value
-  # -- see dua_scaling_slice1.md finding A. The frequent worker-recycle path is covered by env.GUNICORN_CMD_ARGS.
+  # duaServer.terminationGracePeriodSeconds -- grace for in-flight SSE turns to drain on shutdown
   terminationGracePeriodSeconds: 90
   # duaServer.pdb -- PodDisruptionBudget (matches the redash-server PDB; keeps >=1 pod during drains)
   pdb:
     enabled: true
     minAvailable: 1
-  # duaServer.env -- extra env vars merged with the shared env.
-  # GUNICORN_CMD_ARGS raises gunicorn's graceful-timeout (default 30s) so a worker recycling on
-  # --max-requests drains an in-flight SSE turn (bounded by the ~270s app abort) instead of cutting
-  # it at 30s. Covers the frequent worker-recycle path; the rollout path also needs istio (finding A).
+  # duaServer.env -- extra env. GUNICORN_CMD_ARGS raises gunicorn's graceful-timeout so a recycling
+  # worker drains its in-flight SSE turn instead of cutting it at the 30s default.
   env:
     GUNICORN_CMD_ARGS: "--graceful-timeout 300"
   podSecurityContext: {}


### PR DESCRIPTION
Add an optional `dua-server` deployment that serves DUA requests from a dedicated threaded worker pool.

This prevents long-running DUA streams from consuming the main Redash web workers.

The chart adds:

- A dedicated Deployment and internal Service
- A PodDisruptionBudget
- Graceful request draining and pod spreading
- A new `duaServer` configuration block
- Chart version `3.0.14`

## Safety

The feature is disabled by default and has no effect until `duaServer.enabled` is set.

## Requires

https://github.com/scaleapi/redash/pull/137

## Validation

Validated on `redash-next`, including real DUA turns, pod replacement, and continuation on another pod.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional dedicated `dua-server` Deployment, Service, and PodDisruptionBudget to isolate long-lived DUA (SSE) request streams from the main Redash web workers. The feature is disabled by default and requires an explicit opt-in via `duaServer.enabled: true`.

- **Deployment** (`dua-server-deployment.yaml`): Runs the same Redash image with `gthread` workers (2 workers × 16 threads), inherits `server.env` then overrides DUA-specific settings; uses TCP liveness to avoid false restarts under thread saturation, and a `preStop` sleep + `terminationGracePeriodSeconds: 320` to cover the 300-second graceful drain window.
- **Service** (`dua-server-service.yaml`): Internal ClusterIP service with its own `duaServer.service.annotations` escape hatch; targeted via Istio VirtualService routing.
- **PDB** (`dua-server-pdb.yaml`): `maxUnavailable: 1` protects the pool during voluntary disruptions while still allowing single-replica drains.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to enable in non-production first; two concerns flagged in the prior review round (GUNICORN_CMD_ARGS shadowing and readiness probe saturation) remain in the code — one is now explicitly documented as intentional, the other is still a silent footgun for operators with custom CMD args.

The deployment template inherits server.env and then emits duaServer.env — any GUNICORN_CMD_ARGS a user has in server.env is silently dropped and replaced by the DUA value. The author acknowledged env shadowing with a comment but did not add a merge mechanism. The HTTP readiness probe intentionally sheds traffic when gthread slots are full, which was explicitly documented in this revision. Both items were raised in the prior review; neither has been mechanically resolved. The feature is opt-in and disabled by default, which limits blast radius.

templates/dua-server-deployment.yaml — the env ordering between server.env, the three hardcoded worker vars, and duaServer.env warrants a careful second look when operators have custom GUNICORN_CMD_ARGS in server.env.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| templates/dua-server-deployment.yaml | Core of the feature; TCP liveness probe is correct for saturated gthread pools, but the HTTP readiness probe and env-var shadowing for GUNICORN_CMD_ARGS carry known unresolved risks (flagged in prior review threads). |
| templates/dua-server-service.yaml | Internal ClusterIP service with DUA-specific annotation support; clean and correct. |
| templates/dua-server-pdb.yaml | PDB with API version fallback (policy/v1 vs v1beta1); maxUnavailable: 1 is intentional to allow single-replica drains. |
| values.yaml | New duaServer block is well-documented; terminationGracePeriodSeconds (320) now correctly exceeds graceful-timeout (300) + preStopDrainSeconds (15). |
| Chart.yaml | Bumps chart version from 3.0.13 to 3.0.14; correct semver patch bump for an additive, backwards-compatible change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant IstioGW as Istio Gateway/VirtualService
    participant MainSvc as redash Service (main)
    participant DUASvc as redash-dua-server Service
    participant MainPod as server Pod (sync workers)
    participant DUAPod as dua-server Pod (gthread workers)

    Client->>IstioGW: "GET /api/dua/* (SSE stream)"
    IstioGW->>DUASvc: "route /api/dua/* traffic"
    DUASvc->>DUAPod: proxy to gthread worker thread
    DUAPod-->>Client: SSE stream (long-lived, up to 300s drain)

    Client->>IstioGW: "GET /api/* (normal request)"
    IstioGW->>MainSvc: route non-DUA traffic
    MainSvc->>MainPod: proxy to sync worker
    MainPod-->>Client: HTTP response

    Note over DUAPod: On SIGTERM: preStop sleeps 15s,<br/>then gunicorn drains threads for up to 300s.<br/>SIGKILL arrives at second 320.
```
</details>

<sub>Reviews (7): Last reviewed commit: ["docs(dua): clarify readiness load sheddi..."](https://github.com/scaleapi/redash-helm-chart/commit/6da1f54870d4bede2faa6f1afda75bf5b2274722) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46069966)</sub>

<!-- /greptile_comment -->